### PR TITLE
corrected commands

### DIFF
--- a/quickstart.ipynb
+++ b/quickstart.ipynb
@@ -282,9 +282,10 @@
    ],
    "source": [
     "#onto the next notebook!\n",
-    "from notebook import notebookapp\n",
+    "from notebook import app\n",
+    "from jupyter_server import serverapp\n",
     "import webbrowser\n",
-    "jupyter_server = list(notebookapp.list_running_servers())[0][\"url\"]\n",
+    "jupyter_server = list(serverapp.list_running_servers())[0][\"url\"]\n",
     "webbrowser.open(jupyter_server + \"notebooks/create-models.ipynb\")"
    ]
   }


### PR DESCRIPTION
- line 285: notebook is imported from `app.py`, not `notebookapp.py` -- _`notebookapp.py` doesn't appear to exist_
- lines 286 and 288: `list_running_servers` method is defined in `serverapp.py`, not `app.py` -- _method does not exist in `app.py`_